### PR TITLE
systemload show_only_recent won't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ The function takes a table as an optional argument. That table may
 contain:
 
 	.refresh_timeout: Defaults to 10 seconds.
-	.show_only_recent: Show all three values or only the first one?
+	.show_all: Show all three values or by default only the first one?
 
 ## memusage
 Show used memory and total memory in MiB. Read from `/proc/meminfo`.

--- a/vain/widgets.lua
+++ b/vain/widgets.lua
@@ -20,7 +20,7 @@ terminal = ''
 function systemload(args)
     local args = args or {}
     local refresh_timeout = args.refresh_timeout or 10
-    local only_show_recent = args.only_show_recent or true
+    local show_all = args.show_all or false
 
     local mysysload = widget({ type = "textbox" })
     local mysysloadupdate = function()
@@ -28,13 +28,13 @@ function systemload(args)
         local ret = f:read("*all")
         f:close()
 
-        if only_show_recent
+        if show_all
         then
-            local a = string.match(ret, "([^%s]+) ")
-            mysysload.text = string.format("%s", a)
-        else
             local a, b, c = string.match(ret, "([^%s]+) ([^%s]+) ([^%s]+)")
             mysysload.text = string.format("%s %s %s", a, b, c)
+        else
+            local a = string.match(ret, "([^%s]+) ")
+            mysysload.text = string.format("%s", a)
         end
         mysysload.text = ' <span color="' .. beautiful.fg_urgent .. '">'
                          .. mysysload.text .. '</span> '


### PR DESCRIPTION
Hi,
args.only_show_recent or true will always evaluate to true, no matter what value only_show_recent is or if its defined.

I don't know lua to much but i couldn't find a fast solution so i just turn the meaning of the param around.

Greetings
